### PR TITLE
feat(nextjs): add a skipBuild option

### DIFF
--- a/docs/angular/api-next/builders/dev-server.md
+++ b/docs/angular/api-next/builders/dev-server.md
@@ -59,3 +59,11 @@ Default: `false`
 Type: `boolean`
 
 Hide error messages containing server information.
+
+### skipBuild
+
+Default: `false`
+
+Type: `boolean`
+
+Skip building buildTarget.

--- a/docs/react/api-next/builders/dev-server.md
+++ b/docs/react/api-next/builders/dev-server.md
@@ -60,3 +60,11 @@ Default: `false`
 Type: `boolean`
 
 Hide error messages containing server information.
+
+### skipBuild
+
+Default: `false`
+
+Type: `boolean`
+
+Skip building buildTarget.

--- a/docs/web/api-next/builders/dev-server.md
+++ b/docs/web/api-next/builders/dev-server.md
@@ -60,3 +60,11 @@ Default: `false`
 Type: `boolean`
 
 Hide error messages containing server information.
+
+### skipBuild
+
+Default: `false`
+
+Type: `boolean`
+
+Skip building buildTarget.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yolkai/nx-source",
-  "version": "8.12.0-alpha.1",
+  "version": "8.12.0-alpha.2",
   "description": "Extensible Dev Tools for Monorepos",
   "homepage": "https://nx.dev",
   "main": "index.js",

--- a/packages/next/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/next/src/builders/dev-server/dev-server.impl.ts
@@ -26,6 +26,7 @@ export interface NextBuildBuilderOptions extends JsonObject {
   environmentFilePath: string;
   baseUrl: string;
   hostname: string;
+  skipBuild: boolean;
 }
 
 export default createBuilder<NextBuildBuilderOptions>(run);
@@ -78,9 +79,10 @@ function run(
     `http://${options.hostname || 'localhost'}:${options.port}`;
 
   const success: BuilderOutput = { success: true };
-  const build$ = !options.dev
-    ? scheduleTargetAndForget(context, buildTarget)
-    : of(success);
+  const build$ =
+    !options.dev && !options.skipBuild
+      ? scheduleTargetAndForget(context, buildTarget)
+      : of(success);
   const customServer$ = customServerTarget
     ? scheduleTargetAndForget(context, customServerTarget)
     : of(success);

--- a/packages/next/src/builders/dev-server/dev-server.impl.ts
+++ b/packages/next/src/builders/dev-server/dev-server.impl.ts
@@ -11,8 +11,6 @@ import next from 'next';
 import * as path from 'path';
 import { from, Observable, of, forkJoin } from 'rxjs';
 import { switchMap, concatMap, tap } from 'rxjs/operators';
-import * as url from 'url';
-import { prepareConfig } from '../../utils/config';
 import { StartServerFn } from '../../..';
 
 try {

--- a/packages/next/src/builders/dev-server/schema.json
+++ b/packages/next/src/builders/dev-server/schema.json
@@ -41,6 +41,11 @@
       "type": "string",
       "description": "Hostname on which the application is served.",
       "default": null
+    },
+    "skipBuild": {
+      "type": "boolean",
+      "description": "Skip building buildTarget.",
+      "default": false
     }
   },
   "required": []


### PR DESCRIPTION
Based on #3; merge that first.

A new `skipBuild` option enables a `@yolkai/nx-next:dev-server` builder to avoid building `buildTarget` before launching the server.

This means launching the server is faster when the server has already been compiled via `@yolkai/nx-next:build`.