### PR TITLE
feat(nextjs): ensure skipBuild skips building customServerTarget

### DIFF
--- a/docs/angular/api-cypress/builders/cypress.md
+++ b/docs/angular/api-cypress/builders/cypress.md
@@ -52,6 +52,12 @@ Type: `boolean`
 
 Whether or not the Cypress Test Runner will stay open after running tests in a spec file
 
+### group
+
+Type: `string`
+
+A named group for recorded runs in the Cypress dashboard.
+
 ### headless
 
 Default: `false`

--- a/docs/angular/api-next/builders/dev-server.md
+++ b/docs/angular/api-next/builders/dev-server.md
@@ -66,4 +66,4 @@ Default: `false`
 
 Type: `boolean`
 
-Skip building buildTarget.
+Skip building buildTarget and customServerTarget.

--- a/docs/react/api-cypress/builders/cypress.md
+++ b/docs/react/api-cypress/builders/cypress.md
@@ -53,6 +53,12 @@ Type: `boolean`
 
 Whether or not the Cypress Test Runner will stay open after running tests in a spec file
 
+### group
+
+Type: `string`
+
+A named group for recorded runs in the Cypress dashboard.
+
 ### headless
 
 Default: `false`

--- a/docs/react/api-next/builders/dev-server.md
+++ b/docs/react/api-next/builders/dev-server.md
@@ -67,4 +67,4 @@ Default: `false`
 
 Type: `boolean`
 
-Skip building buildTarget.
+Skip building buildTarget and customServerTarget.

--- a/docs/web/api-cypress/builders/cypress.md
+++ b/docs/web/api-cypress/builders/cypress.md
@@ -53,6 +53,12 @@ Type: `boolean`
 
 Whether or not the Cypress Test Runner will stay open after running tests in a spec file
 
+### group
+
+Type: `string`
+
+A named group for recorded runs in the Cypress dashboard.
+
 ### headless
 
 Default: `false`

--- a/docs/web/api-next/builders/dev-server.md
+++ b/docs/web/api-next/builders/dev-server.md
@@ -67,4 +67,4 @@ Default: `false`
 
 Type: `boolean`
 
-Skip building buildTarget.
+Skip building buildTarget and customServerTarget.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yolkai/nx-source",
-  "version": "8.12.0-alpha.3",
+  "version": "8.12.0-alpha.4",
   "description": "Extensible Dev Tools for Monorepos",
   "homepage": "https://nx.dev",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yolkai/nx-source",
-  "version": "8.12.0-alpha.2",
+  "version": "8.12.0-alpha.3",
   "description": "Extensible Dev Tools for Monorepos",
   "homepage": "https://nx.dev",
   "main": "index.js",

--- a/packages/cypress/src/builders/cypress/cypress.impl.ts
+++ b/packages/cypress/src/builders/cypress/cypress.impl.ts
@@ -32,6 +32,7 @@ export interface CypressBuilderOptions extends JsonObject {
   spec?: string;
   copyFiles?: string;
   ciBuildId?: string;
+  group?: string;
 }
 
 try {
@@ -77,7 +78,8 @@ function run(
         options.browser,
         options.env,
         options.spec,
-        options.ciBuildId
+        options.ciBuildId,
+        options.group
       )
     ),
     options.watch ? tap(noop) : take(1),
@@ -109,6 +111,7 @@ function run(
  * @param env
  * @param spec
  * @param ciBuildId
+ * @param group
  */
 function initCypress(
   cypressConfig: string,
@@ -122,7 +125,8 @@ function initCypress(
   browser?: string,
   env?: Record<string, string>,
   spec?: string,
-  ciBuildId?: string
+  ciBuildId?: string,
+  group?: string
 ): Observable<BuilderOutput> {
   // Cypress expects the folder where a `cypress.json` is present
   const projectFolderPath = dirname(cypressConfig);
@@ -152,6 +156,7 @@ function initCypress(
   options.key = key;
   options.parallel = parallel;
   options.ciBuildId = ciBuildId;
+  options.group = group;
 
   return fromPromise<any>(
     !isWatching || headless ? Cypress.run(options) : Cypress.open(options)

--- a/packages/cypress/src/builders/cypress/schema.json
+++ b/packages/cypress/src/builders/cypress/schema.json
@@ -69,6 +69,10 @@
     "ciBuildId": {
       "type": "string",
       "description": "A unique identifier for a run to enable grouping or parallelization."
+    },
+    "group": {
+      "type": "string",
+      "description": "A named group for recorded runs in the Cypress dashboard."
     }
   },
   "additionalProperties": false,

--- a/packages/next/src/builders/dev-server/schema.json
+++ b/packages/next/src/builders/dev-server/schema.json
@@ -44,7 +44,7 @@
     },
     "skipBuild": {
       "type": "boolean",
-      "description": "Skip building buildTarget.",
+      "description": "Skip building buildTarget and customServerTarget.",
       "default": false
     }
   },


### PR DESCRIPTION
Based on https://github.com/Yolk-HQ/nx/pull/5; review that first.

The `skipBuild` option for the `@yolkai/nx-next:dev-server` builder now skips the `customServerTarget` build step. With this option set, the custom server must be built prior to running the server, via `@yolkai/nx-node:build`.